### PR TITLE
Implement ERC2981 to set a standard royalty

### DIFF
--- a/test/pianoking.ts
+++ b/test/pianoking.ts
@@ -95,6 +95,20 @@ describe("Piano King", function () {
     ).to.be.revertedWith("Presale mint not completed");
   });
 
+  it("Should return the right royalty info", async function () {
+    const [receiver, amount] = await pianoKing.royaltyInfo(
+      0,
+      ethers.utils.parseEther("3")
+    );
+    // It should be the address of Piano King wallet
+    expect(receiver).to.be.equal("0xA263f5e0A44Cb4e22AfB21E957dE825027A1e586");
+    // It should be 5 percent of 3 ETH
+    expect(amount).to.be.closeTo(
+      ethers.utils.parseEther((3 * 0.05).toString()),
+      Math.pow(10, 6)
+    );
+  });
+
   /* it("Should set the piano king wallet address", async () => {
     // The address should be the one defined before in the beforeEach hook
     expect(await pianoKing.pianoKingWallet()).to.be.equal(


### PR DESCRIPTION
The ERC2891 (ERC as it is a finalized EIP now) is a recent standard set to standardize the way royalties are paid on smart contracts, especially ERC721 and ERC1155. For further information, please refer to its original specifications https://eips.ethereum.org/EIPS/eip-2981

I have decided to implement it in the Piano King smart contract even most exchanges like OpenSea don't seem to support it at the moment. But I'm pretty sure they will eventually and while we can use their platform to set the royalties, for now, it's nice to have this standard already defined for when it will actually start to be used.