### PR TITLE
Move interaction with Chainlink VRF to a separate contract

### DIFF
--- a/contracts/PianoKing.sol
+++ b/contracts/PianoKing.sol
@@ -5,10 +5,10 @@ import "hardhat/console.sol";
 import "./lib/ERC721.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./PianoKingWhitelist.sol";
-import "@chainlink/contracts/src/v0.8/VRFConsumerBase.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import "./PianoKingRNConsumer.sol";
 
 /**
  * @dev The contract of Piano King NFTs.
@@ -22,7 +22,7 @@ import "@openzeppelin/contracts/interfaces/IERC2981.sol";
  * ERC1155 will further reduce gas fee. With the ERC1155 we interact with just
  * one mapping during mint instead of two for ERC721, but it is a nested mapping.
  */
-contract PianoKing is ERC721, Ownable, VRFConsumerBase, IERC2981 {
+contract PianoKing is ERC721, Ownable, IERC2981 {
   using Address for address payable;
   using Strings for uint256;
 
@@ -52,15 +52,13 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase, IERC2981 {
   uint128 internal randomSeed;
   // The random number used as the base for the incrementor in the sequence
   uint128 internal randomIncrementor;
-
-  // Indicate if a random number has just been requested
-  bool internal hasRequestedRandomness;
   // Indicate if the random number is ready to be used
   bool internal canUseRandomNumber;
   // Allow to keep track of iterations through multiple consecutives
   // transactions for batch mints
   uint16 internal lastBatchIndex;
 
+  PianoKingRNConsumer public pianoKingRNConsumer;
   PianoKingWhitelist public pianoKingWhitelist;
   // Address authorized to withdraw the funds
   address internal pianoKingWallet = 0xA263f5e0A44Cb4e22AfB21E957dE825027A1e586;
@@ -69,23 +67,11 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase, IERC2981 {
   // at least before phase 2
   address internal pianoKingDutchAuction;
 
-  // Data for chainlink
-  bytes32 internal keyhash;
-  uint256 internal fee;
-
-  event RequestedRandomness(bytes32 indexed requestId);
-  event RandomNumberReceived(bytes32 indexed requestId);
-
-  constructor(
-    address _pianoKingWhitelistAddress,
-    address _vrfCoordinator,
-    address _linkToken,
-    bytes32 _keyhash,
-    uint256 _fee
-  ) VRFConsumerBase(_vrfCoordinator, _linkToken) ERC721("Piano King", "PK") {
-    keyhash = _keyhash;
-    fee = _fee;
+  constructor(address _pianoKingWhitelistAddress, address _pianoKingRNConsumer)
+    ERC721("Piano King", "PK")
+  {
     pianoKingWhitelist = PianoKingWhitelist(_pianoKingWhitelistAddress);
+    pianoKingRNConsumer = PianoKingRNConsumer(_pianoKingRNConsumer);
   }
 
   /**
@@ -141,58 +127,6 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase, IERC2981 {
   }
 
   /**
-   * @dev Request the random number to be used for a batch mint
-   */
-  function requestBatchRN() external onlyOwner {
-    // Can trigger only one randomness request at a time
-    require(!hasRequestedRandomness, "Random number already requested");
-    // Check that no batch minting is in progress
-    require(!canUseRandomNumber, "Current minting not finished");
-    // We need some LINK to pay a fee to the oracles
-    require(LINK.balanceOf(address(this)) >= fee, "Not enough LINK");
-    // Request a random number to Chainlink oracles
-    bytes32 requestId = requestRandomness(keyhash, fee);
-    // Indicate that a request has been initiated
-    hasRequestedRandomness = true;
-    emit RequestedRandomness(requestId);
-  }
-
-  /**
-   * Called by Chainlink oracles when sending back a random number for
-   * a given request
-   * This function cannot use more than 200,000 gas or the transaction
-   * will fail
-   */
-  function fulfillRandomness(bytes32 requestId, uint256 randomNumber)
-    internal
-    override
-  {
-    // Put the first 16 bytes (equivalent to a uint128) into randomSeed
-    randomSeed = uint128(
-      randomNumber &
-        0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
-    );
-    // Put the last 16 bytes (equivalent to a uint128) into randomIncrementor
-    randomIncrementor = uint128(
-      randomNumber &
-        0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff
-    );
-    // We're making sure the random incrementor is high enough and most
-    // importantly not zero
-    if (randomIncrementor < 10000) {
-      randomIncrementor += 10000;
-    }
-    // Allow to trigger a new randomness request
-    hasRequestedRandomness = false;
-    // Mark the random number is ready to be used
-    canUseRandomNumber = true;
-    // Just to tell us that the random number has been received
-    // No need to broadcast, however making it public is not problematic
-    // and shouldn't since any data on-chain is public (even private variable)
-    emit RandomNumberReceived(requestId);
-  }
-
-  /**
    * @dev Do a batch mint for the tokens after the first 1000 of presale
    * This function is meant to be called multiple times in row to loop
    * through consecutive ranges of the array to spread gas costs as doing it
@@ -212,6 +146,26 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase, IERC2981 {
   }
 
   /**
+   * @dev Fetch the random numbers from RNConsumer contract
+   */
+  function fetchRandomNumbers() internal {
+    // Will revert if the numbers are not ready
+    (uint128 seed, uint128 incrementor) = pianoKingRNConsumer
+      .getRandomNumbers();
+    // By checking this we enforce the use of a different random number for
+    // each batch mint
+    // There is still the case in which two subsequent random number requests
+    // return the same random number. However since it's a true random number
+    // using the full range of a uint128 this has an extremely low chance of occuring.
+    // And if it does we can still request another number.
+    // We can't use the randomSeed for comparison as it changes during the bathc mint
+    require(incrementor != randomIncrementor, "Cannot use old random numbers");
+    randomIncrementor = incrementor;
+    randomSeed = seed;
+    canUseRandomNumber = true;
+  }
+
+  /**
    * @dev Generic batch mint
    * We don't use neither the _mint nor the _safeMint function
    * to optimize the process as much as possible in terms of gas
@@ -221,8 +175,10 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase, IERC2981 {
   function _batchMint(address[] memory addrs, uint256 count) internal {
     // To mint a batch all of its tokens need to have been preminted
     require(supplyLeft == 0, "Batch not yet sold out");
-    // Check that the random number is ready to be used
-    require(canUseRandomNumber, "Random number not ready");
+    if (!canUseRandomNumber) {
+      // Will revert the transaction if the random numbers are not ready
+      fetchRandomNumbers();
+    }
     // Get the ending index from the start index and the number of
     // addresses to loop through
     uint256 end = lastBatchIndex + count;
@@ -469,14 +425,6 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase, IERC2981 {
       }
       preMintAllowance[addr] = amount;
     }
-  }
-
-  /**
-   * @dev Let the owner of the contract withdraw LINK from the smart contract.
-   * Can be useful if too much was sent or LINK are no longer need on the contract
-   */
-  function withdrawLinkTokens(uint256 amount) external onlyOwner {
-    LINK.transfer(msg.sender, amount);
   }
 
   /**

--- a/contracts/PianoKingRNConsumer.sol
+++ b/contracts/PianoKingRNConsumer.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "hardhat/console.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./PianoKingWhitelist.sol";
+import "@chainlink/contracts/src/v0.8/VRFConsumerBase.sol";
+
+/**
+ * @dev Contract dedicated to request and consume a random number
+ * from Chainlink VRF
+ */
+contract PianoKingRNConsumer is Ownable, VRFConsumerBase {
+  // The random number used as a seed for the random sequence for batch mint
+  uint128 internal randomSeed;
+  // The random number used as the base for the incrementor in the sequence
+  uint128 internal randomIncrementor;
+
+  // Indicate if a random number has just been requested
+  bool internal hasRequestedRandomness;
+  // Indicate if the random number is ready to be used
+  bool internal canUseRandomNumber;
+
+  // Data for chainlink
+  bytes32 internal keyhash;
+  uint256 internal fee;
+
+  event RequestedRandomness(bytes32 indexed requestId);
+  event RandomNumberReceived(bytes32 indexed requestId);
+
+  constructor(
+    address _vrfCoordinator,
+    address _linkToken,
+    bytes32 _keyhash,
+    uint256 _fee
+  ) VRFConsumerBase(_vrfCoordinator, _linkToken) {
+    keyhash = _keyhash;
+    fee = _fee;
+  }
+
+  /**
+   * @dev Request the random number to be used for a batch mint
+   */
+  function requestRandomNumber() external onlyOwner {
+    // Can trigger only one randomness request at a time
+    require(!hasRequestedRandomness, "Random number already requested");
+    // We need some LINK to pay a fee to the oracles
+    require(LINK.balanceOf(address(this)) >= fee, "Not enough LINK");
+    // Request a random number to Chainlink oracles
+    bytes32 requestId = requestRandomness(keyhash, fee);
+    // Indicate that a request has been initiated
+    hasRequestedRandomness = true;
+    canUseRandomNumber = false;
+    emit RequestedRandomness(requestId);
+  }
+
+  /**
+   * Called by Chainlink oracles when sending back a random number for
+   * a given request
+   * This function cannot use more than 200,000 gas or the transaction
+   * will fail
+   */
+  function fulfillRandomness(bytes32 requestId, uint256 randomNumber)
+    internal
+    override
+  {
+    // Put the first 16 bytes (equivalent to a uint128) into randomSeed
+    randomSeed = uint128(
+      randomNumber &
+        0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
+    );
+    // Put the last 16 bytes (equivalent to a uint128) into randomIncrementor
+    randomIncrementor = uint128(
+      randomNumber &
+        0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff
+    );
+    // We're making sure the random incrementor is high enough and most
+    // importantly not zero
+    if (randomIncrementor < 10000) {
+      randomIncrementor += 10000;
+    }
+    // Allow to trigger a new randomness request
+    hasRequestedRandomness = false;
+    // Mark the random number is ready to be used
+    canUseRandomNumber = true;
+    // Just to tell us that the random number has been received
+    // No need to broadcast, however making it public is not problematic
+    // and shouldn't since any data on-chain is public (even private variable)
+    emit RandomNumberReceived(requestId);
+  }
+
+  /**
+   * @dev Get the random numbers
+   */
+  function getRandomNumbers()
+    external
+    view
+    returns (uint128 _randomSeed, uint128 _randomIncrementor)
+  {
+    require(canUseRandomNumber, "Random number not ready");
+    _randomSeed = randomSeed;
+    _randomIncrementor = randomIncrementor;
+  }
+
+  /**
+   * @dev Let the owner of the contract withdraw LINK from the smart contract.
+   * Can be useful if too much was sent or LINK are no longer need on the contract
+   */
+  function withdrawLinkTokens(uint256 amount) external onlyOwner {
+    LINK.transfer(msg.sender, amount);
+  }
+}

--- a/contracts/test/MockPianoKing.sol
+++ b/contracts/test/MockPianoKing.sol
@@ -5,20 +5,8 @@ import "hardhat/console.sol";
 import "../PianoKing.sol";
 
 contract MockPianoKing is PianoKing {
-  constructor(
-    address _pianoKingWhitelistAddress,
-    address _vrfCoordinator,
-    address _linkToken,
-    bytes32 _keyhash,
-    uint256 _fee
-  )
-    PianoKing(
-      _pianoKingWhitelistAddress,
-      _vrfCoordinator,
-      _linkToken,
-      _keyhash,
-      _fee
-    )
+  constructor(address _pianoKingWhitelistAddress, address _pianoKingRNConsumer)
+    PianoKing(_pianoKingWhitelistAddress, _pianoKingRNConsumer)
   {}
 
   function setTotalSupply(uint256 supply) external onlyOwner {

--- a/scripts/testnest/deploy-test.ts
+++ b/scripts/testnest/deploy-test.ts
@@ -24,15 +24,23 @@ async function main() {
   await whiteList.deployed();
   console.log("Whitelist deployed to:", whiteList.address); */
 
+  const PianoKingRNConsumer = await ethers.getContractFactory(
+    "PianoKingRNConsumer"
+  );
+  const pianoKingRNConsumer = await PianoKingRNConsumer.deploy(
+    "0xb3dCcb4Cf7a26f6cf6B120Cf5A73875B7BBc655B",
+    "0x01BE23585060835E02B77ef475b0Cc51aA1e0709",
+    "0x2ed0feb3e7fd2022120aa84fab1945545a9f2ffc9076fd6156fa96eaff4c1311",
+    ethers.utils.parseEther("0.1")
+  );
+  await pianoKingRNConsumer.deployed();
+
   const PianoKing = await ethers.getContractFactory("MockPianoKing");
   // Configuration for Rinkeby as it's the testnet used by OpenSea for tests
   // and also avaible for Chainlink VRF
   const pianoKing = await PianoKing.deploy(
     "0x37E3ACd3f0d4B7d5B8cc31613A2B4e2Cb1A33397",
-    "0xb3dCcb4Cf7a26f6cf6B120Cf5A73875B7BBc655B",
-    "0x01BE23585060835E02B77ef475b0Cc51aA1e0709",
-    "0x2ed0feb3e7fd2022120aa84fab1945545a9f2ffc9076fd6156fa96eaff4c1311",
-    ethers.utils.parseEther("0.1")
+    pianoKingRNConsumer.address
   );
   await pianoKing.deployed();
   console.log("Piano King deployed to:", pianoKing.address);

--- a/scripts/testnest/presale-mint-test.ts
+++ b/scripts/testnest/presale-mint-test.ts
@@ -24,6 +24,15 @@ async function main() {
   );
   console.log("Piano King deployed to:", pianoKing.address);
 
+  const pianoKingRNConsumer = await ethers.getContractAt(
+    "PianoKingRNConsumer",
+    process.env.PIANO_KING_RN_CONSUMER as string
+  );
+  console.log(
+    "Piano King RN Consumer deployed to:",
+    pianoKingRNConsumer.address
+  );
+
   const addresses: string[] = [];
   for (let i = 0; i < 250; i++) {
     // Send everything to the same address to have control over the supply
@@ -32,11 +41,11 @@ async function main() {
   }
 
   // Request a random number to use as seed for the batch
-  const randomnessTx = await pianoKing.requestBatchRN();
+  const randomnessTx = await pianoKingRNConsumer.requestRandomNumber();
   await randomnessTx.wait(1);
   console.log("Random number requested...");
 
-  pianoKing.on("RandomNumberReceived", async () => {
+  pianoKingRNConsumer.on("RandomNumberReceived", async () => {
     console.log("Random number received.");
     const tx = await pianoKing.doBatchMint(addresses, 125);
     await tx.wait(1);


### PR DESCRIPTION
In order to reduce the size and simplify Piano King contract, I've moved the interaction with Chainlink VRF to a separate contract. Piano King contract only interacts with the contract to fetch the random numbers at the start of each batch mint. And the Piano King RN Consumer contract does not need to be aware of the existence of Piano King contract. There's also a check to ensure that a new randomness request is made before initiating a new batch mint to prevent straight in the contract that the same random number is used for different batch mint.

The tests cases have been changed accordingly and all pass. Same for the testnet deploy scripts.