### PR TITLE
Contract to hold the royalties of Piano King NFTs sales

### DIFF
--- a/contracts/PianoKing.sol
+++ b/contracts/PianoKing.sol
@@ -59,6 +59,8 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase {
   PianoKingWhitelist public pianoKingWhitelist;
   // Address authorized to withdraw the funds
   address internal pianoKingWallet = 0xA263f5e0A44Cb4e22AfB21E957dE825027A1e586;
+  // Address where the royalties should be sent to
+  address internal pianoKingFunds;
 
   // Doesn't have to be defined straight away, can be defined later
   // at least before phase 2
@@ -428,6 +430,14 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase {
   function setDutchAuction(address addr) external onlyOwner {
     require(addr != address(0), "Invalid address");
     pianoKingDutchAuction = addr;
+  }
+
+  /**
+   * @dev Set the address of the contract meant to hold the royalties
+   */
+  function setFundsContract(address addr) external onlyOwner {
+    require(addr != address(0), "Invalid address");
+    pianoKingFunds = addr;
   }
 
   /**

--- a/contracts/PianoKing.sol
+++ b/contracts/PianoKing.sol
@@ -69,11 +69,14 @@ contract PianoKing is ERC721, Ownable, IERC2981 {
   // at least before phase 2
   address internal pianoKingDutchAuction;
 
-  constructor(address _pianoKingWhitelistAddress, address _pianoKingRNConsumer)
-    ERC721("Piano King", "PK")
-  {
+  constructor(
+    address _pianoKingWhitelistAddress,
+    address _pianoKingRNConsumer,
+    address _pianoKingFunds
+  ) ERC721("Piano King", "PK") {
     pianoKingWhitelist = PianoKingWhitelist(_pianoKingWhitelistAddress);
     pianoKingRNConsumer = PianoKingRNConsumer(_pianoKingRNConsumer);
+    pianoKingFunds = _pianoKingFunds;
   }
 
   /**
@@ -160,7 +163,7 @@ contract PianoKing is ERC721, Ownable, IERC2981 {
     // return the same random number. However since it's a true random number
     // using the full range of a uint128 this has an extremely low chance of occuring.
     // And if it does we can still request another number.
-    // We can't use the randomSeed for comparison as it changes during the bathc mint
+    // We can't use the randomSeed for comparison as it changes during the batch mint
     require(incrementor != randomIncrementor, "Cannot use old random numbers");
     randomIncrementor = incrementor;
     randomSeed = seed;

--- a/contracts/PianoKing.sol
+++ b/contracts/PianoKing.sol
@@ -554,7 +554,8 @@ contract PianoKing is ERC721, Ownable, VRFConsumerBase, IERC2981 {
     override
     returns (address receiver, uint256 royaltyAmount)
   {
-    receiver = pianoKingWallet;
+    // The funds should be sent to the funds contract
+    receiver = pianoKingFunds;
     // We divide it by 10000 as the royalties can change from
     // 0 to 10000 representing percents with 2 decimals
     royaltyAmount = (salePrice * ROYALTIES) / 10000;

--- a/contracts/PianoKingFunds.sol
+++ b/contracts/PianoKingFunds.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
+/**
+ * @dev Contract holding the funds for the DAOs
+ */
 contract PianoKingFunds is Ownable {
   using Address for address payable;
 
@@ -15,6 +18,9 @@ contract PianoKingFunds is Ownable {
    */
   receive() external payable {}
 
+  /**
+   * @dev Set the addresses of the DAOs
+   */
   function setDAOAddresses(address _firstDao, address _secondDao)
     external
     onlyOwner
@@ -27,12 +33,18 @@ contract PianoKingFunds is Ownable {
     secondDAO = _secondDao;
   }
 
+  /**
+   * @dev Send the funds accumulated by the contract to the DAOs
+   */
   function retrieveFunds() external onlyOwner {
+    // Check that the DAOs addresses have been set
     require(
       firstDAO != address(0) && secondDAO != address(0),
       "DAOs not active"
     );
+    // We split evenly the funds between the 2 DAOs
     uint256 amountToSend = address(this).balance / 2;
+    // And send it to each one of them
     payable(firstDAO).sendValue(amountToSend);
     payable(secondDAO).sendValue(amountToSend);
   }

--- a/contracts/PianoKingFunds.sol
+++ b/contracts/PianoKingFunds.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+contract PianoKingFunds is Ownable {
+  using Address for address payable;
+
+  address private firstDAO;
+  address private secondDAO;
+
+  /**
+   * @dev Allow the contract to receive funds from anyone
+   */
+  receive() external payable {}
+
+  function setDAOAddresses(address _firstDao, address _secondDao)
+    external
+    onlyOwner
+  {
+    require(
+      _firstDao != address(0) && _secondDao != address(0),
+      "Invalid address"
+    );
+    firstDAO = _firstDao;
+    secondDAO = _secondDao;
+  }
+
+  function retrieveFunds() external onlyOwner {
+    require(
+      firstDAO != address(0) && secondDAO != address(0),
+      "DAOs not active"
+    );
+    uint256 amountToSend = address(this).balance / 2;
+    payable(firstDAO).sendValue(amountToSend);
+    payable(secondDAO).sendValue(amountToSend);
+  }
+}

--- a/contracts/test/MockPianoKing.sol
+++ b/contracts/test/MockPianoKing.sol
@@ -5,8 +5,12 @@ import "hardhat/console.sol";
 import "../PianoKing.sol";
 
 contract MockPianoKing is PianoKing {
-  constructor(address _pianoKingWhitelistAddress, address _pianoKingRNConsumer)
-    PianoKing(_pianoKingWhitelistAddress, _pianoKingRNConsumer)
+  constructor(
+    address _pianoKingWhitelistAddress,
+    address _pianoKingRNConsumer,
+    address _pianoKingFunds
+  )
+    PianoKing(_pianoKingWhitelistAddress, _pianoKingRNConsumer, _pianoKingFunds)
   {}
 
   function setTotalSupply(uint256 supply) external onlyOwner {

--- a/scripts/testnest/deploy-test.ts
+++ b/scripts/testnest/deploy-test.ts
@@ -27,6 +27,8 @@ async function main() {
   const PianoKingRNConsumer = await ethers.getContractFactory(
     "PianoKingRNConsumer"
   );
+  // Configuration for Rinkeby as it's the testnet used by OpenSea for tests
+  // and also avaible for Chainlink VRF
   const pianoKingRNConsumer = await PianoKingRNConsumer.deploy(
     "0xb3dCcb4Cf7a26f6cf6B120Cf5A73875B7BBc655B",
     "0x01BE23585060835E02B77ef475b0Cc51aA1e0709",
@@ -35,12 +37,15 @@ async function main() {
   );
   await pianoKingRNConsumer.deployed();
 
+  const PianoKingFunds = await ethers.getContractFactory("PianoKingFunds");
+  const pianoKingFunds = await PianoKingFunds.deploy();
+  await pianoKingFunds.deployed();
+
   const PianoKing = await ethers.getContractFactory("MockPianoKing");
-  // Configuration for Rinkeby as it's the testnet used by OpenSea for tests
-  // and also avaible for Chainlink VRF
   const pianoKing = await PianoKing.deploy(
     "0x37E3ACd3f0d4B7d5B8cc31613A2B4e2Cb1A33397",
-    pianoKingRNConsumer.address
+    pianoKingRNConsumer.address,
+    pianoKingFunds.address
   );
   await pianoKing.deployed();
   console.log("Piano King deployed to:", pianoKing.address);

--- a/test/auction.ts
+++ b/test/auction.ts
@@ -10,6 +10,7 @@ import {
   MockPianoKing,
   PianoKingDutchAuction,
   PianoKingRNConsumer,
+  PianoKingFunds,
 } from "../typechain";
 import { wait } from "../utils";
 
@@ -24,6 +25,7 @@ describe("Dutch Auction", function () {
   let vrfCoordinator: VRFCoordinatorMock;
   let linkToken: LinkToken;
   let dutchAuction: PianoKingDutchAuction;
+  let pianoKingFunds: PianoKingFunds;
   let deployer: SignerWithAddress;
   let buyer: SignerWithAddress;
   let pianoKingWallet: SignerWithAddress;
@@ -71,13 +73,18 @@ describe("Dutch Auction", function () {
     );
     await pianoKingRNConsumer.deployed();
 
+    const PianoKingFunds = await ethers.getContractFactory("PianoKingFunds");
+    pianoKingFunds = await PianoKingFunds.deploy();
+    await pianoKingFunds.deployed();
+
     // Deploy a mock version of Piano King contract which let us modify
     // the total supply, which is necessary as the Dutch auction is only allowed
     // after the first 8000 have been distributed
     const PianoKingFactory = await ethers.getContractFactory("MockPianoKing");
     pianoKing = await PianoKingFactory.deploy(
       whiteList.address,
-      pianoKingRNConsumer.address
+      pianoKingRNConsumer.address,
+      pianoKingFunds.address
     );
     await pianoKing.deployed();
 

--- a/test/mock-pianoking.ts
+++ b/test/mock-pianoking.ts
@@ -10,6 +10,7 @@ import {
   MockPianoKing,
   PianoKingDutchAuction,
   PianoKingRNConsumer,
+  PianoKingFunds,
 } from "../typechain";
 import { getRandomNumber } from "../utils";
 
@@ -18,6 +19,7 @@ describe("Mock Piano King", function () {
   let pianoKing: MockPianoKing;
   let pianoKingRNConsumer: PianoKingRNConsumer;
   let vrfCoordinator: VRFCoordinatorMock;
+  let pianoKingFunds: PianoKingFunds;
   let linkToken: LinkToken;
   let dutchAuction: PianoKingDutchAuction;
   let deployer: SignerWithAddress;
@@ -67,10 +69,15 @@ describe("Mock Piano King", function () {
     );
     await pianoKingRNConsumer.deployed();
 
+    const PianoKingFunds = await ethers.getContractFactory("PianoKingFunds");
+    pianoKingFunds = await PianoKingFunds.deploy();
+    await pianoKingFunds.deployed();
+
     const PianoKingFactory = await ethers.getContractFactory("MockPianoKing");
     pianoKing = await PianoKingFactory.deploy(
       whiteList.address,
-      pianoKingRNConsumer.address
+      pianoKingRNConsumer.address,
+      pianoKingFunds.address
     );
     await pianoKing.deployed();
 

--- a/test/pianoking-funds.ts
+++ b/test/pianoking-funds.ts
@@ -1,0 +1,81 @@
+import { BigNumber } from "@ethersproject/bignumber";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { PianoKingFunds } from "../typechain";
+
+describe("Piano King Funds", function () {
+  let pianoKingFunds: PianoKingFunds;
+  let deployer: SignerWithAddress;
+  let dao1: string;
+  let dao2: string;
+  let exchange: SignerWithAddress;
+  beforeEach(async () => {
+    // Get the local accounts
+    const accounts = await ethers.getSigners();
+    // The default address is the first one
+    deployer = accounts[0];
+    exchange = accounts[1];
+    dao1 = ethers.utils.hexZeroPad(ethers.utils.hexlify(1), 20);
+    dao2 = ethers.utils.hexZeroPad(ethers.utils.hexlify(2), 20);
+
+    const PianoKingFunds = await ethers.getContractFactory("PianoKingFunds");
+    pianoKingFunds = await PianoKingFunds.deploy();
+    await pianoKingFunds.deployed();
+  });
+
+  it("Should be able to deposit ETH", async function () {
+    await expect(
+      exchange.sendTransaction({
+        to: pianoKingFunds.address,
+        value: ethers.utils.parseEther("1"),
+      })
+    ).to.be.not.reverted;
+  });
+
+  it("Should be able to retrieve the funds of the contract", async function () {
+    // Set the addresses of the DAOs on the contract
+    const setDaosTx = await pianoKingFunds.setDAOAddresses(dao1, dao2);
+    await setDaosTx.wait(1);
+
+    // Get the current balances of DAOs
+    const dao1Balance = await ethers.provider.getBalance(dao1);
+    const dao2Balance = await ethers.provider.getBalance(dao2);
+
+    // Mimick the exchange platform sending 1 ETH to the contract
+    // as the royalties on a given sale
+    const sendTx = await exchange.sendTransaction({
+      to: pianoKingFunds.address,
+      value: ethers.utils.parseEther("1"),
+    });
+    await sendTx.wait(1);
+
+    // Send the funds to the DAOs
+    const tx = await pianoKingFunds.retrieveFunds();
+    tx.wait(1);
+
+    // The funds should have been splitted evenly between the two DAOs
+    expect(dao1Balance.add(ethers.utils.parseEther("0.5")));
+    expect(dao2Balance.add(ethers.utils.parseEther("0.5")));
+
+    // The contract should now be empty of any ETH
+    expect(
+      await ethers.provider.getBalance(pianoKingFunds.address)
+    ).to.be.equal(0);
+  });
+
+  it("Should fail to retrieve the funds if the DAOs are not set", async function () {
+    // Mimick the exchange platform sending 1 ETH to the contract
+    // as the royalties on a given sale
+    const sendTx = await exchange.sendTransaction({
+      to: pianoKingFunds.address,
+      value: ethers.utils.parseEther("1"),
+    });
+    await sendTx.wait(1);
+
+    // It should fail as the DAOs addresses have not been set yet
+    await expect(pianoKingFunds.retrieveFunds()).to.be.revertedWith(
+      "DAOs not active"
+    );
+  });
+});

--- a/test/pianoking.ts
+++ b/test/pianoking.ts
@@ -8,12 +8,14 @@ import {
   VRFCoordinatorMock,
   LinkToken,
   PianoKingRNConsumer,
+  PianoKingFunds,
 } from "../typechain";
 
 describe("Piano King", function () {
   let whiteList: PianoKingWhitelist;
   let pianoKing: PianoKing;
   let pianoKingRNConsumer: PianoKingRNConsumer;
+  let pianoKingFunds: PianoKingFunds;
   let vrfCoordinator: VRFCoordinatorMock;
   let linkToken: LinkToken;
   let deployer: SignerWithAddress;
@@ -63,10 +65,15 @@ describe("Piano King", function () {
     );
     await pianoKingRNConsumer.deployed();
 
+    const PianoKingFunds = await ethers.getContractFactory("PianoKingFunds");
+    pianoKingFunds = await PianoKingFunds.deploy();
+    await pianoKingFunds.deployed();
+
     const PianoKingFactory = await ethers.getContractFactory("PianoKing");
     pianoKing = await PianoKingFactory.deploy(
       whiteList.address,
-      pianoKingRNConsumer.address
+      pianoKingRNConsumer.address,
+      pianoKingFunds.address
     );
     await pianoKing.deployed();
 
@@ -110,8 +117,8 @@ describe("Piano King", function () {
       0,
       ethers.utils.parseEther("3")
     );
-    // It should be the address of Piano King wallet
-    expect(receiver).to.be.equal("0xA263f5e0A44Cb4e22AfB21E957dE825027A1e586");
+    // It should be the address of Piano King Funds
+    expect(receiver).to.be.equal(pianoKingFunds.address);
     // It should be 5 percent of 3 ETH
     expect(amount).to.be.closeTo(
       ethers.utils.parseEther((3 * 0.05).toString()),


### PR DESCRIPTION
I've created a smart contract that will serve as the target for the royalties sent back to Piano King by the exchanges such as OpenSea. Since the ERC2981 standard only supports a single address as target of the royalties (to keep a lean approach leaving complex logic up to the implementers), in order to split the payment to multiple addresses the main solution is to use an intermediary contract that will receive the royalties from the exchanges. This contract can receive funds from anyone as the exchange will just do a simple transfer of ETH to that address. Then the owner of the Piano King smart contract can interact with it to initiate the withdrawal of the funds through the `retrieveFunds` function that will split evenly the payment between the two DAOs. 

As of today the DAOs contracts are non-existent but will be settable via the `setDAOAddresses` function that needs both addresses at the same time as they need to be set both anyway. As long as the addresses are not set the `retrieveFunds` function will revert. Also since the DAOs don't exist yet but we need the contract to be deployed now to start receiving the royalties, the constructor doesn't take the addresses as parameters.