### PR TITLE
fix: prevent using contract before requesting randomness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: If you detected a bug in the code
-title: ''
+title: "[BUG]"
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: If you detected a bug in the code
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is:
+- What's going wrong?
+- In which file, at what line and position does the error occur?
+
+**To Reproduce**
+Steps to reproduce the behavior
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/improvement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/improvement-proposal.md
@@ -1,0 +1,11 @@
+---
+name: Improvement proposal
+about: If you would like to propose an improvement
+title: "[IMPROVEMENT]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Description**
+Describe your improvement proposal

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: If you just want to ask a question
+title: "[QUESTION]"
+labels: question
+assignees: ''
+
+---
+
+**Question**
+Ask what you are wondering about

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      
+      - run: npm install 
 
       - run: npx hardhat compile
       
@@ -32,6 +35,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      
+      - run: npm install 
 
       - env:
           REPORT_GAS: true
@@ -47,5 +53,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      
+      - run: npm install 
 
       - run: npx hardhat coverage    

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  compile:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - run: npx hardhat compile
+      
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - env:
+          REPORT_GAS: true
+        run: npx hardhat test    
+        
+  
+    # This workflow contains a single job called "build"
+  coverage:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - run: npx hardhat coverage    

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v2
       
       - run: npm install 
-
+  
       - run: npx hardhat compile
       
   test:
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-node@v2
       
       - run: npm install 
-
+      - run: npx hardhat typechain
       - env:
           REPORT_GAS: true
         run: npx hardhat test    
@@ -56,5 +56,5 @@ jobs:
       - uses: actions/setup-node@v2
       
       - run: npm install 
-
+      - run: npx hardhat typechain
       - run: npx hardhat coverage    

--- a/contracts/PianoKingRNConsumer.sol
+++ b/contracts/PianoKingRNConsumer.sol
@@ -48,9 +48,10 @@ contract PianoKingRNConsumer is Ownable, VRFConsumerBase {
     require(LINK.balanceOf(address(this)) >= fee, "Not enough LINK");
     // Request a random number to Chainlink oracles
     bytes32 requestId = requestRandomness(keyhash, fee);
+    // Prevent using the contract while the random number is being updated
+    canUseRandomNumber = false;
     // Indicate that a request has been initiated
     hasRequestedRandomness = true;
-    canUseRandomNumber = false;
     emit RequestedRandomness(requestId);
   }
 


### PR DESCRIPTION
Please take it all with a grain of salt as I never used solidity before. Happy to be corrected etc
Below is my understanding of this contract, I have only looked at the random number generator so far.

booleans hasRequestedRandomness and canUseRandomNumber have 4 possible states in theory (false, false / false, true / true, false / true, true).
However, it seems the code intention is to only allow three combinations:

- a. false, false => during the initialization of the contract, both start at “false” implicitly (Solidity’s default value).
- b. true, false => when requesting a seed using chainlink
- c. false, true => when there is a seed 

So I assume that the 4th combination (true, true) should not be allowed.

This could be a first step towards refactoring with an `enum` (which would have 3 values instead of 4).